### PR TITLE
Add useMemo support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ function Foo() {
 	const [text, setText] = useState("hello");
 	const [counter, increment] = useReducer(c => c + 1, 0);
 	const rootElement = useRef();
+	const memo = useMemo(() => text.toUpperCase(), ["text"]);
 }
 ```
 
@@ -58,6 +59,10 @@ function Foo() {
 		"counter",
 	);
 	const rootElement = addHookName(useRef(), "rootElement");
+	const memo = addHookName(
+		useMemo(() => text.toUpperCase(), ["text"]),
+		"memo",
+	);
 }
 ```
 

--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,8 @@ module.exports = function ({ types: t, template }) {
 				const callee = path.get("callee");
 
 				if (!callee.isIdentifier()) return;
-				if (!/^(useState|useReducer|useRef)$/.test(callee.node.name)) return;
+				if (!/^(useState|useReducer|useRef|useMemo)$/.test(callee.node.name))
+					return;
 				if (!libs.some(lib => callee.referencesImport(lib))) return;
 
 				const p = path.parentPath.getOuterBindingIdentifierPaths();

--- a/test/transform.test.ts
+++ b/test/transform.test.ts
@@ -1,16 +1,19 @@
-import { transformAsync } from "@babel/core";
-import plugin from "../src";
 import { expect } from "chai";
+
+import { transformAsync } from "@babel/core";
+
+import plugin from "../src";
 
 describe("transform", () => {
 	it("should transform preact code", async () => {
 		const output = await transformAsync(
-			`import { useState, useReducer, useRef } from 'preact/hooks';
+			`import { useState, useReducer, useRef, useMemo } from 'preact/hooks';
 
 function Foo() {
   const [text, setText] = useState('hello');
   const [counter, increment] = useReducer(c => c + 1, 0);
   const rootElement = useRef();
+  const memo = useMemo(() => text.toUpperCase(), ['text']);
 }
 		`,
 			{ plugins: [plugin] },
@@ -18,23 +21,25 @@ function Foo() {
 
 		expect(output!.code).to
 			.equal(`import { addHookName } from "preact/devtools";
-import { useState, useReducer, useRef } from 'preact/hooks';
+import { useState, useReducer, useRef, useMemo } from 'preact/hooks';
 
 function Foo() {
   const [text, setText] = addHookName(useState('hello'), "text");
   const [counter, increment] = addHookName(useReducer(c => c + 1, 0), "counter");
   const rootElement = addHookName(useRef(), "rootElement");
+  const memo = addHookName(useMemo(() => text.toUpperCase(), ['text']), "memo");
 }`);
 	});
 
 	it("should transform with react import", async () => {
 		const output = await transformAsync(
-			`import { useState, useReducer, useRef } from 'react';
+			`import { useState, useReducer, useRef, useMemo } from 'react';
 
 function Foo() {
   const [text, setText] = useState('hello');
   const [counter, increment] = useReducer(c => c + 1, 0);
   const rootElement = useRef();
+  const memo = useMemo(() => text.toUpperCase(), ['text']);
 }
 		`,
 			{ plugins: [plugin] },
@@ -42,23 +47,25 @@ function Foo() {
 
 		expect(output!.code).to
 			.equal(`import { addHookName } from "preact/devtools";
-import { useState, useReducer, useRef } from 'react';
+import { useState, useReducer, useRef, useMemo } from 'react';
 
 function Foo() {
   const [text, setText] = addHookName(useState('hello'), "text");
   const [counter, increment] = addHookName(useReducer(c => c + 1, 0), "counter");
   const rootElement = addHookName(useRef(), "rootElement");
+  const memo = addHookName(useMemo(() => text.toUpperCase(), ['text']), "memo");
 }`);
 	});
 
 	it("should transform with compat import", async () => {
 		const output = await transformAsync(
-			`import { useState, useReducer, useRef } from 'preact/compat';
+			`import { useState, useReducer, useRef, useMemo } from 'preact/compat';
 
 function Foo() {
   const [text, setText] = useState('hello');
   const [counter, increment] = useReducer(c => c + 1, 0);
   const rootElement = useRef();
+  const memo = useMemo(() => text.toUpperCase(), ['text']);
 }
 		`,
 			{ plugins: [plugin] },
@@ -66,12 +73,13 @@ function Foo() {
 
 		expect(output!.code).to
 			.equal(`import { addHookName } from "preact/devtools";
-import { useState, useReducer, useRef } from 'preact/compat';
+import { useState, useReducer, useRef, useMemo } from 'preact/compat';
 
 function Foo() {
   const [text, setText] = addHookName(useState('hello'), "text");
   const [counter, increment] = addHookName(useReducer(c => c + 1, 0), "counter");
   const rootElement = addHookName(useRef(), "rootElement");
+  const memo = addHookName(useMemo(() => text.toUpperCase(), ['text']), "memo");
 }`);
 	});
 
@@ -81,6 +89,7 @@ function Foo() {
   const [text, setText] = State('hello');
   const [counter, increment] = Reducer(c => c + 1, 0);
   const rootElement = Ref();
+  const memo = useMemo(() => text.toUpperCase(), ['text']);
 }
 		`,
 			{ plugins: [plugin] },
@@ -90,17 +99,19 @@ function Foo() {
   const [text, setText] = State('hello');
   const [counter, increment] = Reducer(c => c + 1, 0);
   const rootElement = Ref();
+  const memo = useMemo(() => text.toUpperCase(), ['text']);
 }`);
 	});
 
 	it("should not throw if not destructured", async () => {
 		const output = await transformAsync(
-			`import { useState, useReducer, useRef } from 'preact/hooks';
+			`import { useState, useReducer, useRef, useMemo } from 'preact/hooks';
 
 function Foo() {
   const foo = useState('hello');
   const bar = useReducer(c => c + 1, 0);
   const bob = useRef();
+  const baz = useMemo(() => text.toUpperCase(), ['text']);
 }
 		`,
 			{ plugins: [plugin] },
@@ -108,35 +119,38 @@ function Foo() {
 
 		expect(output!.code).to
 			.equal(`import { addHookName } from "preact/devtools";
-import { useState, useReducer, useRef } from 'preact/hooks';
+import { useState, useReducer, useRef, useMemo } from 'preact/hooks';
 
 function Foo() {
   const foo = addHookName(useState('hello'), "foo");
   const bar = addHookName(useReducer(c => c + 1, 0), "bar");
   const bob = addHookName(useRef(), "bob");
+  const baz = addHookName(useMemo(() => text.toUpperCase(), ['text']), "baz");
 }`);
 	});
 
 	it("should not throw if not used", async () => {
 		const output = await transformAsync(
-			`import { useState, useReducer, useRef } from 'preact/hooks';
+			`import { useState, useReducer, useRef, useMemo } from 'preact/hooks';
 
 function Foo() {
   useState('hello');
   useReducer(c => c + 1, 0);
   useRef();
+  useMemo(() => text.toUpperCase(), ['text']);
 }
 		`,
 			{ plugins: [plugin] },
 		);
 
 		expect(output!.code).to
-			.equal(`import { useState, useReducer, useRef } from 'preact/hooks';
+			.equal(`import { useState, useReducer, useRef, useMemo } from 'preact/hooks';
 
 function Foo() {
   useState('hello');
   useReducer(c => c + 1, 0);
   useRef();
+  useMemo(() => text.toUpperCase(), ['text']);
 }`);
 	});
 });


### PR DESCRIPTION
Add the `useMemo` to the set of hooks annotated with their name for display in devtools.